### PR TITLE
refactor: replace app section with anima card styling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,48 @@ import { AvatarGrid } from "@/components/avatar-grid"
 import { AppSection } from "@/components/app-section"
 import { BottomNavigation } from "@/components/bottom-navigation"
 
+const tarotItems = [
+  {
+    id: 1,
+    image: "/image.png",
+    category: "결혼운",
+    emoji: "💍",
+    title: "우리는 결혼까지 갈 수 있을까?",
+    originalPrice: "19,900원",
+    discount: "75%",
+    finalPrice: "4,900원",
+  },
+  {
+    id: 2,
+    image: "/image-2.png",
+    category: "연애운",
+    emoji: "💖",
+    title: "그 사람의 진심은 어디쯤일까?",
+    originalPrice: "21,000원",
+    discount: "77%",
+    finalPrice: "4,900원",
+  },
+  {
+    id: 3,
+    image: "/image-3.png",
+    category: "연애운",
+    emoji: "💖",
+    title: "솔로 탈출, 나에게도 곧 연애가 올까?",
+    originalPrice: "21,000원",
+    discount: "77%",
+    finalPrice: "4,900원",
+  },
+  {
+    id: 4,
+    image: "/image-4.png",
+    category: "재회운",
+    title: "그 사람과, 다시 이어질 수 있을까?",
+    originalPrice: "21,000원",
+    discount: "77%",
+    finalPrice: "4,900원",
+  },
+]
+
 export default function HomePage() {
   return (
     <div className="min-h-screen bg-gray-50">
@@ -13,112 +55,95 @@ export default function HomePage() {
         <div className="px-4 py-6 space-y-6">
           <ZenPointsCard />
           <AvatarGrid />
+          <AppSection title="타로 베스트" items={tarotItems} />
           <AppSection
             title="서비스 제공소"
             items={[
-              {
-                id: 1,
-                title: "웹툰보기, 서비스 및 이벤트 정보, 리뷰 등등",
-                subtitle: "웹툰보기 가능한 8,000원",
-                image: "/webtoon-app-icon.png",
-                price: "8,000원",
-              },
-              {
-                id: 2,
-                title: "네 번째 웹툰보는 곳 추천해",
-                subtitle: "웹툰보기 가능한 8,000원",
-                image: "/webtoon-recommendation-icon.png",
-                price: "8,000원",
-              },
-              {
-                id: 3,
-                title: "웹툰보는 곳 검색 및 리뷰 및 추천해",
-                subtitle: "웹툰보기 가능한 20,000원",
-                image: "/webtoon-search-icon.png",
-                price: "20,000원",
-              },
-              {
-                id: 4,
-                title: "서비스 및 이벤트 정보, 추천해",
-                subtitle: "웹툰보기 가능한 8,000원",
-                image: "/event-service-icon.png",
-                price: "8,000원",
-              },
+                {
+                  id: 1,
+                  title: "웹툰보기, 서비스 및 이벤트 정보, 리뷰 등등",
+                  image: "/webtoon-app-icon.png",
+                  finalPrice: "8,000원",
+                },
+                {
+                  id: 2,
+                  title: "네 번째 웹툰보는 곳 추천해",
+                  image: "/webtoon-recommendation-icon.png",
+                  finalPrice: "8,000원",
+                },
+                {
+                  id: 3,
+                  title: "웹툰보는 곳 검색 및 리뷰 및 추천해",
+                  image: "/webtoon-search-icon.png",
+                  finalPrice: "20,000원",
+                },
+                {
+                  id: 4,
+                  title: "서비스 및 이벤트 정보, 추천해",
+                  image: "/event-service-icon.png",
+                  finalPrice: "8,000원",
+                },
             ]}
-            buttonText="더보기"
-            buttonColor="bg-blue-500"
           />
 
           <AppSection
             title="디자인 제공소"
             items={[
-              {
-                id: 5,
-                title: "기획, 웹디자인 및 앱 디자인",
-                subtitle: "웹툰보기 가능한 4,000원",
-                image: "/design-planning-icon.png",
-                price: "4,000원",
-              },
-              {
-                id: 6,
-                title: "그 외에 디자인 기타 디자인업무",
-                subtitle: "웹툰보기 가능한 4,000원",
-                image: "/design-work-icon.png",
-                price: "4,000원",
-              },
-              {
-                id: 7,
-                title: "웹 디자인, 디자인 및 웹사이트 등등",
-                subtitle: "웹툰보기 가능한 4,000원",
-                image: "/web-design-icon.png",
-                price: "4,000원",
-              },
-              {
-                id: 8,
-                title: "그 외에 디자인 디자인업무 및 디자인해",
-                subtitle: "웹툰보기 가능한 4,000원",
-                image: "/design-service-icon.png",
-                price: "4,000원",
-              },
+                {
+                  id: 5,
+                  title: "기획, 웹디자인 및 앱 디자인",
+                  image: "/design-planning-icon.png",
+                  finalPrice: "4,000원",
+                },
+                {
+                  id: 6,
+                  title: "그 외에 디자인 기타 디자인업무",
+                  image: "/design-work-icon.png",
+                  finalPrice: "4,000원",
+                },
+                {
+                  id: 7,
+                  title: "웹 디자인, 디자인 및 웹사이트 등등",
+                  image: "/web-design-icon.png",
+                  finalPrice: "4,000원",
+                },
+                {
+                  id: 8,
+                  title: "그 외에 디자인 디자인업무 및 디자인해",
+                  image: "/design-service-icon.png",
+                  finalPrice: "4,000원",
+                },
             ]}
-            buttonText="더보기"
-            buttonColor="bg-blue-500"
           />
 
           <AppSection
             title="AI 개발 업무용 (개발자)"
             items={[
-              {
-                id: 9,
-                title: "실무에서 웹개발자로 일하고있는 개발자가 직접 개발해 드립니다",
-                subtitle: "웹툰보기 가능한 48,000원",
-                image: "/web-developer-icon.png",
-                price: "48,000원",
-              },
-              {
-                id: 10,
-                title: "실무에서 웹개발자로 일하고있는 개발자가 직접 개발해 드립니다",
-                subtitle: "웹툰보기 가능한 60,000원",
-                image: "/developer-service-icon.png",
-                price: "60,000원",
-              },
-              {
-                id: 11,
-                title: "실무에서 웹개발자로 일하고있는 개발자가 직접 개발해 드립니다",
-                subtitle: "웹툰보기 가능한 20,000원",
-                image: "/development-work-icon.png",
-                price: "20,000원",
-              },
-              {
-                id: 12,
-                title: "실무에서 웹개발자로 일하고있는 개발자가 직접 개발해 드립니다",
-                subtitle: "웹툰보기 가능한 20,000원",
-                image: "/ai-development-icon.png",
-                price: "20,000원",
-              },
+                {
+                  id: 9,
+                  title: "실무에서 웹개발자로 일하고있는 개발자가 직접 개발해 드립니다",
+                  image: "/web-developer-icon.png",
+                  finalPrice: "48,000원",
+                },
+                {
+                  id: 10,
+                  title: "실무에서 웹개발자로 일하고있는 개발자가 직접 개발해 드립니다",
+                  image: "/developer-service-icon.png",
+                  finalPrice: "60,000원",
+                },
+                {
+                  id: 11,
+                  title: "실무에서 웹개발자로 일하고있는 개발자가 직접 개발해 드립니다",
+                  image: "/development-work-icon.png",
+                  finalPrice: "20,000원",
+                },
+                {
+                  id: 12,
+                  title: "실무에서 웹개발자로 일하고있는 개발자가 직접 개발해 드립니다",
+                  image: "/ai-development-icon.png",
+                  finalPrice: "20,000원",
+                },
             ]}
-            buttonText="더보기"
-            buttonColor="bg-blue-500"
           />
         </div>
       </main>

--- a/src/components/app-section.tsx
+++ b/src/components/app-section.tsx
@@ -1,46 +1,89 @@
-import { Card } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
 
 interface AppSectionItem {
   id: number
-  title: string
-  subtitle: string
   image: string
-  price: string
+  title: string
+  category?: string
+  emoji?: string
+  originalPrice?: string
+  discount?: string
+  finalPrice: string
 }
 
 interface AppSectionProps {
   title: string
   items: AppSectionItem[]
-  buttonText: string
-  buttonColor: string
+  moreText?: string
 }
 
-export function AppSection({ title, items, buttonText, buttonColor }: AppSectionProps) {
+export function AppSection({ title, items, moreText = "더보기" }: AppSectionProps) {
   return (
-    <div className="space-y-4">
-      <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-
-      <div className="space-y-3">
-        {items.map((item) => (
-          <Card key={item.id} className="p-4 hover:shadow-md transition-shadow cursor-pointer">
-            <div className="flex gap-3">
-              <div className="w-12 h-12 bg-gray-100 rounded-lg flex-shrink-0 overflow-hidden">
-                <img src={item.image || "/placeholder.svg"} alt={item.title} className="w-full h-full object-cover" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <h3 className="text-sm font-medium text-gray-900 line-clamp-2 mb-1">{item.title}</h3>
-                <p className="text-xs text-gray-500 mb-2">{item.subtitle}</p>
-                <div className="text-sm font-semibold text-blue-600">{item.price}</div>
-              </div>
+    <div className="w-full">
+      <div className="inline-flex flex-col items-start pb-2.5">
+        <Card className="inline-flex flex-col items-start gap-4 bg-white rounded-[10px] border-0 shadow-none w-full">
+          <CardContent className="flex flex-col p-0 w-full">
+            <div className="flex flex-col w-full">
+              <h2 className="mt-[-1px] text-xl font-bold leading-[28.4px] tracking-[-0.2px] text-[#161741]">
+                {title}
+              </h2>
             </div>
-          </Card>
-        ))}
+            <div className="flex flex-col gap-5 mt-4 w-full">
+              <div className="flex flex-col gap-[26px] min-h-[300px]">
+                {items.map((item) => (
+                  <div key={item.id} className="flex w-full items-start gap-[18px]">
+                    <div
+                      className="h-[104px] w-[121px] rounded-[10px] bg-cover bg-center flex-shrink-0"
+                      style={{ backgroundImage: `url(${item.image})` }}
+                    />
+                    <div className="flex flex-1 flex-col justify-between pb-0.5">
+                      <div className="flex flex-col gap-[6.86px] pr-[71.33px]">
+                        {item.category && (
+                          <Badge className="inline-flex h-[21px] items-center gap-[3px] rounded-full bg-[#dde9ff] px-1.5 py-[1.25px] text-[#5791ff] hover:bg-[#dde9ff]">
+                            {item.emoji && (
+                              <span className="text-[10px] font-bold leading-[15px]">{item.emoji}</span>
+                            )}
+                            <span className="text-[11px] font-bold leading-[16.5px]">
+                              {item.category}
+                            </span>
+                          </Badge>
+                        )}
+                        <div className="text-base font-bold leading-[22.7px] text-[#161741]">
+                          {item.title}
+                        </div>
+                      </div>
+                      <div className="inline-flex h-[23px] items-center gap-1 overflow-hidden">
+                        {item.originalPrice && (
+                          <div className="text-sm font-bold leading-[21px] text-[#454567] line-through">
+                            {item.originalPrice}
+                          </div>
+                        )}
+                        <div className="inline-flex items-start gap-px">
+                          {item.discount && (
+                            <div className="text-lg font-bold leading-[27px] text-[#5791ff]">
+                              {item.discount}
+                            </div>
+                          )}
+                          <div className="text-lg font-bold leading-[27px] text-[#161741]">
+                            {item.finalPrice}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <Button className="h-12 w-full items-center justify-center rounded-[10px] bg-[#5791ff] px-[179.25px] py-[11.5px] hover:bg-[#4a7de6]">
+                <span className="text-base font-semibold leading-6 text-white">
+                  {moreText}
+                </span>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
       </div>
-
-      <Button className={`w-full ${buttonColor} hover:opacity-90 text-white rounded-lg py-3`} variant="default">
-        {buttonText}
-      </Button>
     </div>
   )
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary: "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive: "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }


### PR DESCRIPTION
## Summary
- replace existing app section with Anima-styled AppSection component
- remove legacy card-section component and apply unified section styling on homepage

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_e_68b38bcad7808323b801690851023bb1