### PR TITLE
feat: add card section component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,51 @@
 import { Header } from "@/components/header"
 import { ZenPointsCard } from "@/components/zen-points-card"
 import { AvatarGrid } from "@/components/avatar-grid"
+import { CardSection } from "@/components/card-section"
 import { AppSection } from "@/components/app-section"
 import { BottomNavigation } from "@/components/bottom-navigation"
+
+const tarotCards = [
+  {
+    id: 1,
+    image: "/image.png",
+    category: "결혼운",
+    emoji: "💍",
+    title: "우리는 결혼까지 갈 수 있을까?",
+    originalPrice: "19,900원",
+    discount: "75%",
+    finalPrice: "4,900원",
+  },
+  {
+    id: 2,
+    image: "/image-2.png",
+    category: "연애운",
+    emoji: "💖",
+    title: "그 사람의 진심은 어디쯤일까?",
+    originalPrice: "21,000원",
+    discount: "77%",
+    finalPrice: "4,900원",
+  },
+  {
+    id: 3,
+    image: "/image-3.png",
+    category: "연애운",
+    emoji: "💖",
+    title: "솔로 탈출, 나에게도 곧 연애가 올까?",
+    originalPrice: "21,000원",
+    discount: "77%",
+    finalPrice: "4,900원",
+  },
+  {
+    id: 4,
+    image: "/image-4.png",
+    category: "재회운",
+    title: "그 사람과, 다시 이어질 수 있을까?",
+    originalPrice: "21,000원",
+    discount: "77%",
+    finalPrice: "4,900원",
+  },
+]
 
 export default function HomePage() {
   return (
@@ -13,6 +56,7 @@ export default function HomePage() {
         <div className="px-4 py-6 space-y-6">
           <ZenPointsCard />
           <AvatarGrid />
+          <CardSection title="타로 베스트" cards={tarotCards} />
           <AppSection
             title="서비스 제공소"
             items={[

--- a/src/components/card-section.tsx
+++ b/src/components/card-section.tsx
@@ -1,0 +1,89 @@
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+
+interface CardItem {
+  id: number
+  image: string
+  title: string
+  category?: string
+  emoji?: string
+  originalPrice?: string
+  discount?: string
+  finalPrice: string
+}
+
+interface CardSectionProps {
+  title: string
+  cards: CardItem[]
+  moreText?: string
+}
+
+export function CardSection({ title, cards, moreText = "더보기" }: CardSectionProps) {
+  return (
+    <div className="w-full">
+      <div className="inline-flex flex-col items-start pb-2.5">
+        <Card className="inline-flex flex-col items-start gap-4 bg-white rounded-[10px] border-0 shadow-none w-full">
+          <CardContent className="flex flex-col p-0 w-full">
+            <div className="flex flex-col w-full">
+              <h2 className="mt-[-1px] text-xl font-bold leading-[28.4px] tracking-[-0.2px] text-[#161741]">
+                {title}
+              </h2>
+            </div>
+            <div className="flex flex-col gap-5 mt-4 w-full">
+              <div className="flex flex-col gap-[26px] min-h-[300px]">
+                {cards.map((card) => (
+                  <div key={card.id} className="flex w-full items-start gap-[18px]">
+                    <div
+                      className="h-[104px] w-[121px] rounded-[10px] bg-cover bg-center flex-shrink-0"
+                      style={{ backgroundImage: `url(${card.image})` }}
+                    />
+                    <div className="flex flex-1 flex-col justify-between pb-0.5">
+                      <div className="flex flex-col gap-[6.86px] pr-[71.33px]">
+                        {card.category && (
+                          <Badge className="inline-flex h-[21px] items-center gap-[3px] rounded-full bg-[#dde9ff] px-1.5 py-[1.25px] text-[#5791ff] hover:bg-[#dde9ff]">
+                            {card.emoji && (
+                              <span className="text-[10px] font-bold leading-[15px]">{card.emoji}</span>
+                            )}
+                            <span className="text-[11px] font-bold leading-[16.5px]">
+                              {card.category}
+                            </span>
+                          </Badge>
+                        )}
+                        <div className="text-base font-bold leading-[22.7px] text-[#161741]">
+                          {card.title}
+                        </div>
+                      </div>
+                      <div className="inline-flex h-[23px] items-center gap-1 overflow-hidden">
+                        {card.originalPrice && (
+                          <div className="text-sm font-bold leading-[21px] text-[#454567] line-through">
+                            {card.originalPrice}
+                          </div>
+                        )}
+                        <div className="inline-flex items-start gap-px">
+                          {card.discount && (
+                            <div className="text-lg font-bold leading-[27px] text-[#5791ff]">
+                              {card.discount}
+                            </div>
+                          )}
+                          <div className="text-lg font-bold leading-[27px] text-[#161741]">
+                            {card.finalPrice}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <Button className="h-12 w-full items-center justify-center rounded-[10px] bg-[#5791ff] px-[179.25px] py-[11.5px] hover:bg-[#4a7de6]">
+                <span className="text-base font-semibold leading-6 text-white">
+                  {moreText}
+                </span>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary: "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive: "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }


### PR DESCRIPTION
## Summary
- port Anima card section into reusable CardSection component with Tailwind styling
- add Badge UI primitive
- show tarot card section on homepage

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b38bcad7808323b801690851023bb1