### PR TITLE
feat(lib): add zedi HTML parser

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,14 @@
+export interface CarouselSlide {
+  imageUrl: string;
+  linkUrl: string;
+}
+
+export interface CardItem {
+  name: string;
+  price: string;
+}
+
+export interface CardSection {
+  title: string;
+  items: CardItem[];
+}

--- a/src/lib/zediParser.ts
+++ b/src/lib/zediParser.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { CarouselSlide, CardSection, CardItem } from './types';
+
+export async function parseZedi(): Promise<{ slides: CarouselSlide[]; sections: CardSection[] }> {
+  const filePath = path.join(process.cwd(), 'zedi-crawl/index.html');
+  const html = await fs.readFile(filePath, 'utf8');
+
+  const parser = new DOMParser();
+  const document = parser.parseFromString(html, 'text/html');
+
+  const slides: CarouselSlide[] = [];
+  document.querySelectorAll('.swiper-slide').forEach((slide) => {
+    const imageUrl = slide.querySelector('img')?.getAttribute('src') ?? '';
+    const linkUrl = slide.querySelector('a')?.getAttribute('href') ?? '';
+    slides.push({ imageUrl, linkUrl });
+  });
+
+  const sections: CardSection[] = [];
+  document.querySelectorAll('.css-iqgnoi').forEach((section) => {
+    const title = section.querySelector('.css-zerbqo')?.textContent?.trim() ?? '';
+    const items: CardItem[] = [];
+    section.querySelectorAll('.css-yfunor').forEach((item) => {
+      const name = item.querySelector('.css-dabu68')?.textContent?.trim() ?? '';
+      const price = item.querySelector('.css-e8mbwt')?.textContent?.trim() ?? '';
+      if (name) {
+        items.push({ name, price });
+      }
+    });
+    sections.push({ title, items });
+  });
+
+  return { slides, sections };
+}
+


### PR DESCRIPTION
## Summary
- define CarouselSlide, CardItem, and CardSection types
- implement DOMParser-based HTML parser for Zendi crawl data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b4c90e69cc8323ae9b3416f34c8f3b